### PR TITLE
Add dev requirements needed for building the docs.

### DIFF
--- a/requirements-dev.pip
+++ b/requirements-dev.pip
@@ -1,0 +1,2 @@
+Sphinx>=1.2
+sphinxcontrib-httpdomain>=1.2.0


### PR DESCRIPTION
See http://go-optouts-api.readthedocs.org/ for the docs (currently not built).
