### PR TITLE
Add opt out backends.

### DIFF
--- a/opt_out_http_api/backends/interface.py
+++ b/opt_out_http_api/backends/interface.py
@@ -1,0 +1,15 @@
+"""
+This is where the description of what an opt out backend should be
+capable of will go. Such a description is called an 'interface'.
+
+The package 'zope.interfaces' provides tools for writing these. You
+can find documentation at
+http://docs.zope.org/zope.interface/README.html#defining-interfaces.
+
+Initially the interface will have just two methods -- one for getting
+and opt out and one for setting an opt out.
+
+The implementations of the interfaces should go in memory.py and
+riak.py. Start with the memory.py one and leave the Riak one for
+later.
+"""

--- a/opt_out_http_api/backends/memory.py
+++ b/opt_out_http_api/backends/memory.py
@@ -1,0 +1,9 @@
+"""
+This is where we will put the in-memory opt out store that we
+will use for testing and simple demos.
+
+Essentially it's the same as the implementation that exists in
+api_methods right now (i.e. a list of opt outs in memory), but
+it will conform to the interface in backends.interface and
+perhaps be a little nicer.
+"""

--- a/opt_out_http_api/backends/riak.py
+++ b/opt_out_http_api/backends/riak.py
@@ -1,0 +1,5 @@
+"""
+This is where the "real" backend implementation will live.
+
+Not worry about it for the moment.
+"""


### PR DESCRIPTION
Currently the opt out store uses an in-memory dictionary for storing opt outs. We need to hook it up to Vumi Go's opt out models, that first requires abstracting out the interface to the backend a bit. This ticket is for creating the necessary interfaces.
