### PR TITLE
Add auth bouncer support.

### DIFF
--- a/go_optouts/auth.py
+++ b/go_optouts/auth.py
@@ -1,0 +1,54 @@
+""" Utilities for authenticating requests. """
+
+import treq
+from twisted.internet.defer import succeed, inlineCallbacks, returnValue
+from zope.interface import implements, Interface
+
+
+class IAuthenticator(Interface):
+    """ Authenticator interface. """
+
+    def owner_id(request):
+        """ Retrieve an owner_id for a request.
+
+        :type request:
+            A Klein request object.
+        :param request:
+            The request to authenticate.
+
+        :return:
+            A deferred that fires with either an owner_id or None if the
+            request could not be authenticated.
+        """
+
+
+class RequestHeaderAuth(object):
+
+    implements(IAuthenticator)
+
+    def owner_id(self, request):
+        return succeed(request.getHeader('X-Owner-ID'))
+
+
+class BouncerAuth(object):
+
+    implements(IAuthenticator)
+
+    def __init__(self, auth_bouncer_url):
+        self._auth_bouncer_url = auth_bouncer_url.rstrip('/')
+
+    @inlineCallbacks
+    def owner_id(self, request):
+        auth_headers = {}
+        auth = request.getHeader('Authorization')
+        if auth:
+            auth_headers['Authorization'] = auth
+        uri = "".join([self._auth_bouncer_url, request.path])
+        resp = yield treq.get(uri, headers=auth_headers, persistent=False)
+        yield resp.content()
+        if resp.code >= 400:
+            returnValue(None)
+        x_owner_id = resp.headers.getRawHeaders('X-Owner-Id')
+        if x_owner_id is None or len(x_owner_id) != 1:
+            returnValue(None)
+        returnValue(x_owner_id[0])

--- a/go_optouts/tests/test_api.py
+++ b/go_optouts/tests/test_api.py
@@ -4,6 +4,7 @@ from twisted.internet.defer import inlineCallbacks
 from vumi.tests.helpers import VumiTestCase
 
 from go_optouts.api import API
+from go_optouts.auth import RequestHeaderAuth
 from go_optouts.store.memory import MemoryOptOutBackend
 from go_optouts.tests.utils import SiteHelper
 
@@ -13,8 +14,9 @@ class TestApi(VumiTestCase):
     def setUp(self):
         self.owner_id = "owner-1"
         self.backend = MemoryOptOutBackend()
+        self.auth = RequestHeaderAuth()
         self.collection = self.backend.get_opt_out_collection(self.owner_id)
-        self.app = API(self.backend)
+        self.app = API(self.backend, self.auth)
         self.site = Site(self.app.app.resource())
 
         self.site_helper = yield self.add_helper(

--- a/go_optouts/tests/test_auth.py
+++ b/go_optouts/tests/test_auth.py
@@ -1,0 +1,113 @@
+""" Test for go_optouts.auth. """
+
+from zope.interface.verify import verifyClass, verifyObject
+
+from twisted.internet.defer import inlineCallbacks, Deferred
+from twisted.web.resource import Resource
+from twisted.web.server import Request, Site
+
+from vumi.tests.helpers import VumiTestCase
+
+from go_optouts.auth import IAuthenticator, RequestHeaderAuth, BouncerAuth
+from go_optouts.tests.utils import SiteHelper
+
+
+def mk_request(path=None, headers=None):
+    request = Request(channel=None, queued=True)
+    if path:
+        request.path = path
+    if headers:
+        for k, v in headers.items():
+            request.requestHeaders.addRawHeader(k, v)
+    return request
+
+
+class TestRequestHeaderAuth(VumiTestCase):
+    def test_class_interface(self):
+        self.assertTrue(verifyClass(IAuthenticator, RequestHeaderAuth))
+
+    def test_instance_iface(self):
+        auth = RequestHeaderAuth()
+        self.assertTrue(verifyObject(IAuthenticator, auth))
+
+    @inlineCallbacks
+    def test_owner_id_present(self):
+        auth = RequestHeaderAuth()
+        request = mk_request(headers={"X-Owner-ID": "owner-1"})
+        owner_id_d = auth.owner_id(request)
+        self.assertTrue(isinstance(owner_id_d, Deferred))
+        self.assertEqual((yield owner_id_d), "owner-1")
+
+    @inlineCallbacks
+    def test_owner_id_absent(self):
+        auth = RequestHeaderAuth()
+        request = mk_request()
+        owner_id_d = auth.owner_id(request)
+        self.assertTrue(isinstance(owner_id_d, Deferred))
+        self.assertEqual((yield owner_id_d), None)
+
+
+class DummyAuthResource(Resource):
+
+    isLeaf = True
+
+    def __init__(self):
+        self._requests = []
+        self._responses = []
+
+    def add_response(self, code=401, body="Unauthorized", owner_id=None):
+        self._responses.append({
+            'code': code,
+            'body': body,
+            'owner_id': owner_id
+        })
+
+    def pop_response(self):
+        if not self._responses:
+            self.add_response()
+        return self._responses.pop(0)
+
+    def render(self, request):
+        self._requests.append(request)
+        response = self.pop_response()
+        request.setResponseCode(response['code'])
+        if response['owner_id']:
+            request.setHeader('X-Owner-ID', response['owner_id'])
+        return response['body']
+
+
+class TestBouncerAuth(VumiTestCase):
+    @inlineCallbacks
+    def setUp(self):
+        self.auth_resource = DummyAuthResource()
+        self.site = Site(self.auth_resource)
+        self.site_helper = yield self.add_helper(SiteHelper(self.site))
+
+    @property
+    def auth_url(self):
+        return self.site_helper.url
+
+    def test_class_interface(self):
+        self.assertTrue(verifyClass(IAuthenticator, BouncerAuth))
+
+    def test_instance_iface(self):
+        auth = BouncerAuth(self.auth_url)
+        self.assertTrue(verifyObject(IAuthenticator, auth))
+
+    @inlineCallbacks
+    def test_auth_success(self):
+        self.auth_resource.add_response(
+            code=200, body='Authorized', owner_id='owner-1')
+        auth = BouncerAuth(self.auth_url)
+        request = mk_request(path="/foo")
+        owner_id_d = auth.owner_id(request)
+        self.assertTrue(isinstance(owner_id_d, Deferred))
+        self.assertEqual((yield owner_id_d), "owner-1")
+
+    @inlineCallbacks
+    def test_auth_failed(self):
+        auth = BouncerAuth(self.auth_url)
+        request = mk_request(path="/foo")
+        owner_id_d = auth.owner_id(request)
+        self.assertTrue(isinstance(owner_id_d, Deferred))
+        self.assertEqual((yield owner_id_d), None)


### PR DESCRIPTION
Currently the opt out API supports reading the owner from the `X-Owner-ID` but we need to support passing requests via an authentication bouncer.
